### PR TITLE
Fix Cors Errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,16 @@
     "16": "images/icons/grey-box_16.png"
   },
 
-  "permissions": ["webRequest", "storage", "tabs", "downloads"],
+  "permissions": [
+    "webRequest",
+    "storage",
+    "tabs",
+    "downloads"
+  ],
+
+  "host_permissions": [
+    "<all_urls>"
+  ],
 
   "action": {
     "default_popup": "html/popup.html"


### PR DESCRIPTION
# Summary

Added <all_urls> to host_permissions, so the extension can access pages url. Addresses cors.

## References

* https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
* https://groups.google.com/a/chromium.org/g/chromium-extensions/c/aVn9F6S_z68?pli=1
